### PR TITLE
Version 0.1.2 - Stable(mostly)

### DIFF
--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -112,7 +112,7 @@ def getboneconstraints(selectedbones):
 
 def checkboneconstrainttarget(bonelist):
     activearmature = bpy.context.selected_objects[0].name
-    selectedbones = getselectedbones()
+    selectedbones = bonelist
 
     for i in selectedbones:
             #Set the current bone's name

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -131,6 +131,9 @@ def checkboneconstrainttarget(bonelist):
 
             for con in i.constraints:
                 target = con.target
+                if target == None:
+                    return "ARMATURE"
+            
                 objtarget = target.type
                 
                 print(objtarget)

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -110,8 +110,32 @@ def getboneconstraints(selectedbones):
     if len(constraints) > 0:
         return constraints
 
-def setboneconstraintspace(activearmature, selectedbones, constrainttotarget,targetspace,ownerspace):
+def checkboneconstrainttarget(bonelist):
+    activearmature = bpy.context.selected_objects[0].name
+    selectedbones = getselectedbones()
 
+    for i in selectedbones:
+            #Set the current bone's name
+            bonename = i.name
+
+            #The desired Bone
+            boneToSelect = bpy.data.objects[activearmature].pose.bones[bonename].bone
+            #Set as active 
+            bpy.context.object.data.bones.active = boneToSelect
+            #Select in viewport
+            boneToSelect.select = True
+            
+            #Check if target of constraint is armature object or other
+            
+
+
+            for con in i.constraints:
+                target = con.target
+                objtarget = target.type
+                
+                print(objtarget)
+
+def setboneconstraintspace(activearmature, selectedbones, constrainttotarget,targetspace,ownerspace):
 
     #Go through each bone selected
     for i in selectedbones:
@@ -124,8 +148,15 @@ def setboneconstraintspace(activearmature, selectedbones, constrainttotarget,tar
         bpy.context.object.data.bones.active = boneToSelect
         #Select in viewport
         boneToSelect.select = True
+        
+        #Check if target of constraint is armature object or other
+
+
 
         for con in i.constraints:
+            target = con.target
+            objtarget = target.type
+
             bpy.context.object.data.bones.active = boneToSelect
             if constrainttotarget == "all" or "All":
                 #Adjust each constraint on the selected bone (i) to be in Local space (need to adjust to work off of a menu str or enum later)

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -118,6 +118,7 @@ def checkboneconstrainttarget(bonelist):
             for con in i.constraints:
                 print(con.name)
                 target = con.target
+                objtarget = target.type
                 print(f"Target is = {target}")
                 if target == None:
                     print(f"NONE -- {objtarget}")

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -52,7 +52,7 @@ def getselectedbonesforenum(self, context):
 
 #Functional
 def colorizerig(context):
-    if poll("POSE") or poll("EDIT") == True:
+    if poll("POSE") == True:
         lst_bones = getselectedbones(context)
         lst_bonenames = []
         for i in lst_bones:
@@ -63,12 +63,12 @@ def colorizerig(context):
 
             iendswithL = False
             iendswithR = False
-            i = i.upper()
+            iupper = i.upper()
 
-            if i.endswith("_L") or i.endswith(".L") == True:
+            if iupper.endswith("_L") or iupper.endswith(".L") == True:
                 iendswithL = True
             
-            if i.endswith("_R") or i.endswith(".R") == True:
+            if iupper.endswith("_R") or iupper.endswith(".R") == True:
                 iendswithR = True
 
             if iendswithL and iendswithR != True:

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -11,26 +11,22 @@ def poll(compstr):
     active_object = bpy.context.mode
     if active_object == compstr:
         bool = True
-        print(active_object + " --- " + "True")
         return bool
     if active_object != compstr:
         bool = False
-        print(active_object + " --- " + "False")
         return bool
+
 #Functional only when taking in context
 def getselectedbones(context):
     bonelist = []
     bones = bpy.context.selected_pose_bones_from_active_object
     for i in bones:
-        print(i.name)
         bonelist.append(i)
     return bonelist
 
 def getselectedbonesforenum(self, context):
-    print("Selected bones for enum")
     constrainttypestmp = []
     enumlist = []
-    print(enumlist)
 
     addtoenum = tuple(("0","All","Target All Detected Constraints"))
     enumlist.append(addtoenum)
@@ -50,7 +46,6 @@ def getselectedbonesforenum(self, context):
         
         addtoenum = tuple((indexstr, i, description))
         enumlist.append(addtoenum)
-        print(enumlist)
     return enumlist
     
         
@@ -59,30 +54,18 @@ def getselectedbonesforenum(self, context):
 def colorizerig(context):
     if poll("POSE") == True:
         lst_bonenames = getselectedbones(context)
-        print(lst_bonenames)
         for i in lst_bonenames:
             if i.endswith("_L") and i.endswith ("_R") != True:
-                print("Else --")
-                print(i)
                 bpy.context.object.data.bones[i].color.palette = 'THEME13'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME13'
             if i.endswith("_L"):
-                print("L ---")
-                print(i)
                 bpy.context.object.data.bones[i].color.palette = 'THEME02'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME02'
 
 
             if i.endswith("_R"):
-                print("R ---")
-                print(i)
                 bpy.context.object.data.bones[i].color.palette = 'THEME03'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME03'
-            
-            else:
-                print("Error-04-ColorizeRig-NameNotIdentifying")
-    else:
-        print("Error-3-ColorizeRig-PollNotEqual")
 
 #Functional
 def searchforbone(selected_armature, temp_bonetofind):
@@ -92,8 +75,6 @@ def searchforbone(selected_armature, temp_bonetofind):
     if poll("EDIT_ARMATURE") == True:
         bpy.ops.armature.select_all(action='DESELECT')
         bpy.data.objects[str(selected_armature)].data.bones[temp_bonetofind].select=True
-    else:
-        print("Error-4-SearchForBone-PollNotEqual")
 #Functional
 def getexistingfilesindirectories(basedirectorytosearch):
     
@@ -112,52 +93,34 @@ def getboneconstraints(selectedbones):
             if con.type not in constraints:
                 constrainttoaddtolist = con.type
                 constraints.append(constrainttoaddtolist)
-                print("Added " + constrainttoaddtolist + " To Constraints List")
     if len(constraints) > 0:
         return constraints
 
 def setboneconstraintspace(activearmature, selectedbones, constrainttotarget,targetspace,ownerspace):
-
-    spaceconsole(5)
-    print(f"Active Armature = {activearmature}  -- Selected Bones = {selectedbones}  -- Constraint To Target = {constrainttotarget}  -- Targetspace = {targetspace}  -- Ownerspace = {ownerspace}")
 
 
     #Go through each bone selected
     for i in selectedbones:
         #Set the current bone's name
         bonename = i.name
-        print("Bonename = " + bonename)
 
         #The desired Bone
         boneToSelect = bpy.data.objects[activearmature].pose.bones[bonename].bone
-        spaceconsole(2)
-        print(f"Bone to select = {boneToSelect}")
         #Set as active 
         bpy.context.object.data.bones.active = boneToSelect
         #Select in viewport
         boneToSelect.select = True
-        spaceconsole(1)
-        print("i = " + i.name)
-        print("i is selected? = " + bpy.context.active_pose_bone.name)
 
         for con in i.constraints:
             bpy.context.object.data.bones.active = boneToSelect
             if constrainttotarget == "all" or "All":
-                print("Contraint To Target is All")
                 #Adjust each constraint on the selected bone (i) to be in Local space (need to adjust to work off of a menu str or enum later)
                 bpy.context.object.pose.bones[bonename].constraints[con.name].target_space = targetspace
                 bpy.context.object.pose.bones[bonename].constraints[con.name].owner_space = ownerspace
-                #confirm all is working
-                print("set target to " + targetspace + " space")
-                print("set owner to " + ownerspace + " space")
-            elif con.type == constrainttotarget: 
-                print ("Constraint To Target is: " + str(constrainttotarget))               
+            elif con.type == constrainttotarget:               
                 #Adjust each constraint on the selected bone (i) to be in Local space (need to adjust to work off of a menu str or enum later)
                 bpy.context.object.pose.bones[bonename].constraints[con.name].target_space = targetspace
                 bpy.context.object.pose.bones[bonename].constraints[con.name].owner_space = ownerspace
-                #confirm all is working
-                print("set target to " + targetspace + " space")
-                print("set owner to " + ownerspace + " space")
         
 #____________________________________________________________________________________________
 #____________________________________________________________________________________________

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -60,15 +60,24 @@ def colorizerig(context):
             lst_bonenames.append(bname)
         
         for i in lst_bonenames:
-            if i.endswith("_L") and i.endswith ("_R") != True:
+
+            iendswithL = False
+            iendswithR = False
+            i = i.upper()
+
+            if i.endswith("_L") or i.endswith(".L") == True:
+                iendswithL = True
+            
+            if i.endswith("_R") or i.endswith(".R") == True:
+                iendswithR = True
+
+            if iendswithL and iendswithR != True:
                 bpy.context.object.data.bones[i].color.palette = 'THEME13'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME13'
-            if i.endswith("_L"):
+            if iendswithL:
                 bpy.context.object.data.bones[i].color.palette = 'THEME02'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME02'
-
-
-            if i.endswith("_R"):
+            if iendswithR:
                 bpy.context.object.data.bones[i].color.palette = 'THEME03'
                 bpy.context.object.pose.bones[i].color.palette = 'THEME03'
 

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -121,11 +121,17 @@ def checkboneconstrainttarget(bonelist):
                 target = con.target
                 print(f"Target is = {target}")
                 if target == None:
+                    print(f"NONE -- {objtarget}")
                     return "ARMATURE"
             
                 objtarget = target.type
-                
-                print(objtarget)
+                if objtarget == "ARMATURE":
+                    print(f"ARMATURE -- {objtarget}")
+                    return objtarget
+                if objtarget != "ARMATURE":
+                    print(f"NOT ARMATURE -- {objtarget}")
+                    return "NOTARMATURE"
+
 
 def setboneconstraintspace(activearmature, selectedbones, constrainttotarget,targetspace,ownerspace):
 

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -52,7 +52,7 @@ def getselectedbonesforenum(self, context):
 
 #Functional
 def colorizerig(context):
-    if poll("POSE") == True:
+    if poll("POSE") or poll("EDIT") == True:
         lst_bones = getselectedbones(context)
         lst_bonenames = []
         for i in lst_bones:

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -115,22 +115,11 @@ def checkboneconstrainttarget(bonelist):
     selectedbones = bonelist
 
     for i in selectedbones:
-            #Set the current bone's name
-            bonename = i.name
-
-            #The desired Bone
-            boneToSelect = bpy.data.objects[activearmature].pose.bones[bonename].bone
-            #Set as active 
-            bpy.context.object.data.bones.active = boneToSelect
-            #Select in viewport
-            boneToSelect.select = True
-            
-            #Check if target of constraint is armature object or other
-            
-
-
+            print(i.name)
             for con in i.constraints:
+                print(con.name)
                 target = con.target
+                print(f"Target is = {target}")
                 if target == None:
                     return "ARMATURE"
             

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -119,12 +119,11 @@ def checkboneconstrainttarget(bonelist):
                 print(con.name)
                 target = con.target
                 objtarget = target.type
-                print(f"Target is = {target}")
+                print(f"Target is = {objtarget}")
+
                 if target == None:
                     print(f"NONE -- {objtarget}")
                     return "NOTARMATURE"
-            
-                objtarget = target.type
                 if objtarget == "ARMATURE":
                     print(f"ARMATURE -- {objtarget}")
                     return objtarget

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -110,19 +110,18 @@ def getboneconstraints(selectedbones):
     if len(constraints) > 0:
         return constraints
 
+#Mostly Functional -- Needs to be expanded to update enum based on the selection option of another enum
 def checkboneconstrainttarget(bonelist):
     selectedbones = bonelist
 
     for i in selectedbones:
-            print(i.name)
-            print(i.constraints)
             for con in i.constraints:
                 print(con.name)
                 target = con.target
                 print(f"Target is = {target}")
                 if target == None:
                     print(f"NONE -- {objtarget}")
-                    return "ARMATURE"
+                    return "NOTARMATURE"
             
                 objtarget = target.type
                 if objtarget == "ARMATURE":

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -111,11 +111,11 @@ def getboneconstraints(selectedbones):
         return constraints
 
 def checkboneconstrainttarget(bonelist):
-    activearmature = bpy.context.selected_objects[0].name
     selectedbones = bonelist
 
     for i in selectedbones:
             print(i.name)
+            print(i.constraints)
             for con in i.constraints:
                 print(con.name)
                 target = con.target

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -116,19 +116,14 @@ def checkboneconstrainttarget(bonelist):
 
     for i in selectedbones:
             for con in i.constraints:
-                print(con.name)
                 target = con.target
                 objtarget = target.type
-                print(f"Target is = {objtarget}")
 
                 if target == None:
-                    print(f"NONE -- {objtarget}")
                     return "NOTARMATURE"
                 if objtarget == "ARMATURE":
-                    print(f"ARMATURE -- {objtarget}")
                     return objtarget
                 if objtarget != "ARMATURE":
-                    print(f"NOT ARMATURE -- {objtarget}")
                     return "NOTARMATURE"
 
 

--- a/von_buttoncontrols.py
+++ b/von_buttoncontrols.py
@@ -53,7 +53,12 @@ def getselectedbonesforenum(self, context):
 #Functional
 def colorizerig(context):
     if poll("POSE") == True:
-        lst_bonenames = getselectedbones(context)
+        lst_bones = getselectedbones(context)
+        lst_bonenames = []
+        for i in lst_bones:
+            bname = i.name
+            lst_bonenames.append(bname)
+        
         for i in lst_bonenames:
             if i.endswith("_L") and i.endswith ("_R") != True:
                 bpy.context.object.data.bones[i].color.palette = 'THEME13'

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -45,6 +45,7 @@ def updatetargetspaceenumlist(self, context):
     print("UPDATING")
     factor = von_buttoncontrols.checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
     enumlist = []
+    print(f"Factor - {factor}")
     if factor == "ARMATURE":
         print("ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -172,7 +172,7 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
         mytool=scene.my_tool
         enum = mytool.ExistingBoneConstraints_enum
         layout.prop(mytool, "ExistingBoneConstraints_enum")
-        layout.prop(self, "targetspace_enum")
+        layout.prop(mytool, "targetspace_enum")
         layout.prop(self, "ownerspace_enum")
         
 

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -53,6 +53,9 @@ def updatetargetspaceenumlist(self, context):
         print("NOT ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
         return enumlist
+    if factor == None:
+        print("NONEVALUE")
+        return[("-1000", "NONEVALUE, REPORT ERROR")]
     
 
 # ------------------------------------------------------------------------

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -47,6 +47,7 @@ def updatetargetspaceenumlist(self, context):
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
     if factor != "ARMATURE":
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
+    return enumlist
 
 # ------------------------------------------------------------------------
 #    Scene Properties

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -41,6 +41,8 @@ def updateexistingboneconstraintsenum(self, context):
     von_buttoncontrols.getselectedbonesforenum(self, context)
 
 def updatetargetspaceenumlist(self, context):
+    von_createcontrols.spaceconsole(5)
+    print("UPDATING")
     factor = von_buttoncontrols.checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
     enumlist = []
     if factor == "ARMATURE":
@@ -150,8 +152,9 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
 
         constraintchosen = int(mytool.ExistingBoneConstraints_enum)
         targetspacechosen = int(mytool.targetspace_enum)
-        targetspacechosen = targetspacechosen - 1
         ownerspacechosen = int(self.ownerspace_enum)
+
+        targetspacechosen = targetspacechosen - 1
         ownerspacechosen = ownerspacechosen - 1
         ownerspace = spacebruhs[ownerspacechosen]
         targetspace = spacebruhs[targetspacechosen]

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -41,7 +41,7 @@ def updateexistingboneconstraintsenum(self, context):
     von_buttoncontrols.getselectedbonesforenum(self, context)
 
 def updatetargetspaceenumlist(self, context):
-    factor = checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
+    factor = von_buttoncontrols.checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
     enumlist = []
     if factor == "ARMATURE":
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
@@ -99,7 +99,7 @@ class MySettings(PropertyGroup):
     targetspace_enum: EnumProperty(
         name = "Target Space - ",
         description = "The Setting Target Space will be set to",   
-        items = [],
+        items = updatetargetspaceenumlist,
         update = updatetargetspaceenumlist
     ) # type: ignore
 

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -144,7 +144,7 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
         selectedbones = getselectedbones(context)
 
         constraintchosen = int(mytool.ExistingBoneConstraints_enum)
-        targetspacechosen = int(self.targetspace_enum)
+        targetspacechosen = int(mytool.targetspace_enum)
         targetspacechosen = targetspacechosen - 1
         ownerspacechosen = int(self.ownerspace_enum)
         ownerspacechosen = ownerspacechosen - 1

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -38,7 +38,6 @@ from .von_createcontrols import *
 #    Dynamic Enum Population
 # ------------------------------------------------------------------------
 def updateexistingboneconstraintsenum(self, context):
-    print("Update Enum!!!")
     von_buttoncontrols.getselectedbonesforenum(self, context)
 
 # ------------------------------------------------------------------------
@@ -138,8 +137,6 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
         constraints = getselectedbonesforenum(self, context)
         selectedbones = getselectedbones(context)
 
-
-
         constraintchosen = int(mytool.ExistingBoneConstraints_enum)
         targetspacechosen = int(self.targetspace_enum)
         targetspacechosen = targetspacechosen - 1
@@ -198,8 +195,6 @@ class Von_Dropdown_AddCustomBoneshape(bpy.types.Operator):
             temp_total_string = f"'{str(temp_total)}'"
             #idescription = f"Click To Create {i} As An Avalible Boneshape"
             listofstrings = tuple((temp_total_string, os.path.splitext(os.path.basename(i))[0], i))
-            print(os.path.splitext(os.path.basename(i))[0])
-            print(f"List of strings = {listofstrings}")
             sendtoenum.append(listofstrings)
 
     filetoloadselection_enum : EnumProperty(

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -40,6 +40,14 @@ from .von_createcontrols import *
 def updateexistingboneconstraintsenum(self, context):
     von_buttoncontrols.getselectedbonesforenum(self, context)
 
+def updatetargetspaceenumlist(self, context):
+    factor = checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
+    enumlist = []
+    if factor == "ARMATURE":
+        enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
+    if factor != "ARMATURE":
+        enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
+
 # ------------------------------------------------------------------------
 #    Scene Properties
 # ------------------------------------------------------------------------
@@ -88,7 +96,12 @@ class MySettings(PropertyGroup):
         update = updateexistingboneconstraintsenum
     ) # type: ignore
 
-
+    targetspace_enum: EnumProperty(
+        name = "Target Space - ",
+        description = "The Setting Target Space will be set to",   
+        items = [],
+        update = updatetargetspaceenumlist
+    ) # type: ignore
 
 # ------------------------------------------------------------------------
 #    Popout Submenu's
@@ -113,13 +126,6 @@ class VonPanel_RiggingTools__Submenu_BoneSearch(bpy.types.Operator):
 class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operator):
     bl_idname = "von.masssetboneconstraintspace"
     bl_label = "Mass Set Constraint Space"
-
-    targetspace_enum: EnumProperty(
-        name = "Target Space - ",
-        description = "The Setting Target Space will be set to",   
-        items = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
-
-    ) # type: ignore
 
     ownerspace_enum: EnumProperty(
         name = "Owner Space - ",

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -54,7 +54,7 @@ def updatetargetspaceenumlist(self, context):
         print("ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
         return enumlist
-    if factor != "ARMATURE":
+    if factor == "NOTARMATURE":
         print("NOT ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
         return enumlist

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -106,7 +106,7 @@ class MySettings(PropertyGroup):
     targetspace_enum: EnumProperty(
         name = "Target Space - ",
         description = "The Setting Target Space will be set to",   
-        items = [("10000","You Shouldn't Be Seeing This", "No Seriously Report This")],
+        items = updatetargetspaceenumlist,
         update = updatetargetspaceenumlist
     ) # type: ignore
 

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -142,7 +142,7 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
     ownerspace_enum: EnumProperty(
         name = "Owner Space - ",
         description = "The Setting Owner Space will be set to",   
-        items = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
+        items = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description")]
     ) # type: ignore
 
  

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -46,6 +46,10 @@ def updatetargetspaceenumlist(self, context):
     factor = von_buttoncontrols.checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
     enumlist = []
     print(f"Factor - {factor}")
+
+    if factor == None:
+        print("NONEVALUE")
+        return[("-1000", "NONEVALUE, REPORT ERROR")]
     if factor == "ARMATURE":
         print("ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
@@ -54,9 +58,6 @@ def updatetargetspaceenumlist(self, context):
         print("NOT ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
         return enumlist
-    if factor == None:
-        print("NONEVALUE")
-        return[("-1000", "NONEVALUE, REPORT ERROR")]
     
 
 # ------------------------------------------------------------------------

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -104,7 +104,7 @@ class MySettings(PropertyGroup):
     targetspace_enum: EnumProperty(
         name = "Target Space - ",
         description = "The Setting Target Space will be set to",   
-        items = updatetargetspaceenumlist,
+        items = [("10000","You Shouldn't Be Seeing This", "No Seriously Report This")],
         update = updatetargetspaceenumlist
     ) # type: ignore
 

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -315,7 +315,7 @@ class VonPanel_RiggingTools(VonPanel, bpy.types.Panel):
         layout.operator("von.addcustomboneshape")
         layout.operator("von.savenewcontrol")
         layout.operator("von.masssetboneconstraintspace")
-        
+        layout.operator("von.colorizerig")
 
 
         row.label(text= "Weight Painting", icon= 'CUBE')
@@ -335,7 +335,7 @@ class VonPanel_AnimationTools(VonPanel, bpy.types.Panel):
 
         #Bone Search
         layout.operator_context = 'INVOKE_DEFAULT'
-        layout.operator("von.colorizerig")
+        #layout.operator("von.colorizerig")
 
 classes = (
     MySettings,

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -44,10 +44,14 @@ def updatetargetspaceenumlist(self, context):
     factor = von_buttoncontrols.checkboneconstrainttarget(von_buttoncontrols.getselectedbones(context))
     enumlist = []
     if factor == "ARMATURE":
+        print("ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
+        return enumlist
     if factor != "ARMATURE":
+        print("NOT ARMATURE")
         enumlist = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description")]
-    return enumlist
+        return enumlist
+    
 
 # ------------------------------------------------------------------------
 #    Scene Properties

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -128,7 +128,7 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
         items = [("1", "LOCAL", "Description"), ("2", "WORLD", "Description"), ("3", "CUSTOM", "Description"), ("4", "POSE", "Description"), ("5", "LOCAL_WITH_PARENT", "Description"), ("6", "LOCAL_OWNER_ORIENT", "Description")]
     ) # type: ignore
 
-
+ 
     def execute(self, context):
         scene = context.scene
         mytool=scene.my_tool
@@ -137,6 +137,8 @@ class VonPanel_RiggingTools_Submenu_MassSetBoneConstraintSpace(bpy.types.Operato
         spacebruhs = ("LOCAL", "WORLD", "CUSTOM","POSE","LOCAL_WITH_PARENT","LOCAL_OWNER_ORIENT")
         constraints = getselectedbonesforenum(self, context)
         selectedbones = getselectedbones(context)
+
+
 
         constraintchosen = int(mytool.ExistingBoneConstraints_enum)
         targetspacechosen = int(self.targetspace_enum)


### PR DESCRIPTION
Added:

1. Colorize Rig
- Only requires either . or _ -- L or l / R or r at the end to colorize, leaves all other bones uncoloured

2. Mass modify constraint spaces
- Allows modifying constraint spaces of selected bones
- Allows for specific types of constraints to be targeted
- KNOWN ISSUE: If the target of your constraint is a non-armature object or isn't designated, using anything other than the first 3 options on the dropdown (Local, World, Custom) will cause it to error out. This will be sorted in a later issue once I work out how to get an enum to effect another enum's update cycle after first displaying
