### PR TITLE
Fixing Active Armature Issues

### DIFF
--- a/von_createcontrols.py
+++ b/von_createcontrols.py
@@ -162,8 +162,12 @@ def movetocollection(NameOfCollection,object_name):
     bpy.data.collections[NameOfCollection].hide_viewport = True
         
 
+# ------------------------------------------------------------------------
+#    Create Animation Retargeter Functions 
+# ------------------------------
 
-
+def retargetanimations(targetarmature, sourcearmatures):
+    print("FUCK")
 
 # ------------------------------------------------------------------------
 #    Create Multiuse Functions #Functional

--- a/von_menu_popup.py
+++ b/von_menu_popup.py
@@ -484,21 +484,29 @@ class Von_InitializeArmaturesOperator(bpy.types.Operator):
 
 
 
+        # The armatures need unique names or otherwise the script will not work as blender cannot decide which armatures are 
+        bpy.ops.object.mode_set(mode='EDIT')
+        bpy.ops.object.mode_set(mode='OBJECT')
 
+        active_object = bpy.context.selected_objects[0]
+        #active_object = bpy.context.active_object
         target_armature = None
         source_armatures = []
-        active_object = bpy.context.view_layer.objects.active
-
+        endswithnumbers = False
+        
         if active_object and active_object.type == 'ARMATURE':
             target_armature = active_object
-        for obj in bpy.context.selected_objects:
-            if obj.type == 'ARMATURE' and obj != target_armature:
-                source_armatures.append(obj)
-        
+        if target_armature:
+            for obj in bpy.context.selected_objects:
+                if obj.type == 'ARMATURE' and obj != target_armature.name:
+                    source_armatures.append(obj)
+
+            # Debug output
+            #print(f"Target Armature: {target_armature.name if target_armature else 'None'}")
+            #print(f"Source Armatures: {[obj.name for obj in source_armatures]}")
         if target_armature:
             #Generating the bones
             von_vrctools.generateextrabone(source_armatures, target_armature, undetectedbones, self)
-
             von_vrctools.moveskeletalmesh(selected_armatures, target_armature,self)
 
         return {'FINISHED'}

--- a/von_vrctools.py
+++ b/von_vrctools.py
@@ -200,7 +200,8 @@ def generateextrabone(source_armatures, target_armature, bonelist, self):
                     continue
             else:
                 continue
-
+    
+    bpy.context.view_layer.objects.active = target_armature
 
     setallarmaturecontext('POSE')
     for i in target_bones:


### PR DESCRIPTION
Active armature was being moved away from the initially active one (So from TARGET to all of the source armatures) without being moved back before proceding with other actions, leading to other context sensitive actions being performed on the last SOURCE armature rather than the TARGET armature